### PR TITLE
Add trade direction and chronological ordering

### DIFF
--- a/ct/ct/EndOfDataMessage.cs
+++ b/ct/ct/EndOfDataMessage.cs
@@ -12,5 +12,10 @@ namespace ct
         }
 
         public override MessageKind Kind => MessageKind.EndOfData;
+
+        public override string ToString()
+        {
+            return $"EndOfData {Stamp:O}";
+        }
     }
 }

--- a/ct/ct/Program.cs
+++ b/ct/ct/Program.cs
@@ -1,10 +1,27 @@
-﻿namespace ct
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+
+namespace ct
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            Console.WriteLine("Hello, World!");
+            string path = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "bybit", "BTCUSD2020-03-12.csv.gz");
+            using FileStream file = File.OpenRead(path);
+            using GZipStream zip = new GZipStream(file, CompressionMode.Decompress);
+
+            DataSource source = new ByBitPublicFileDataSource(zip);
+            await foreach (Message message in source.GetMessagesAsync())
+            {
+                Console.WriteLine(message.ToString());
+                if (message.Kind == MessageKind.EndOfData)
+                {
+                    break;
+                }
+            }
         }
     }
 }

--- a/ct/ct/TimeMessage.cs
+++ b/ct/ct/TimeMessage.cs
@@ -12,5 +12,10 @@ namespace ct
         }
 
         public override MessageKind Kind => MessageKind.Time;
+
+        public override string ToString()
+        {
+            return $"Time {Stamp:O}";
+        }
     }
 }

--- a/ct/ct/TradeDirection.cs
+++ b/ct/ct/TradeDirection.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ct
+{
+    /// <summary>
+    /// Indicates whether a trade is long or short.
+    /// </summary>
+    public enum TradeDirection
+    {
+        Long,
+        Short
+    }
+}

--- a/ct/ct/TradeMessage.cs
+++ b/ct/ct/TradeMessage.cs
@@ -12,12 +12,21 @@ namespace ct
         public readonly double StartPrice;
         public readonly double EndPrice;
         public readonly double Volume;
+        public readonly TradeDirection Direction;
 
-        public TradeMessage(DateTime stamp, double startPrice, double endPrice, double volume) : base(stamp)
+        public TradeMessage(DateTime stamp, double startPrice, double endPrice, double volume, TradeDirection direction) : base(stamp)
         {
-
+            StartPrice = startPrice;
+            EndPrice = endPrice;
+            Direction = direction;
+            Volume = volume;
         }
 
         public override MessageKind Kind => MessageKind.Trade;
+
+        public override string ToString()
+        {
+            return $"Trade {Stamp:O} start={StartPrice} end={EndPrice} volume={Volume} direction={Direction}";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- parse bybit trades in chronological order
- detect long/short trade direction
- store direction in `TradeMessage`
- reference sample data file relative to the executable

## Testing
- `dotnet build ct/ct/ct.csproj -nologo`
- `dotnet run --project ct/ct/ct.csproj --no-build | head -n 15`
