### PR TITLE
Split tests into individual xUnit cases

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,5 +18,15 @@ jobs:
         run: dotnet restore ct/ct.sln
       - name: Build
         run: dotnet build ct/ct.sln --configuration Release --no-restore
-      - name: Run tests
-        run: dotnet run --project ct/ct.tests/ct.tests.csproj --configuration Release
+      - name: Order2020IsChronological
+        run: dotnet test ct/ct.tests/ct.tests.csproj --no-build --configuration Release --filter FullyQualifiedName=ct.tests.ByBitTests.Order2020IsChronological
+      - name: Order2022IsChronological
+        run: dotnet test ct/ct.tests/ct.tests.csproj --no-build --configuration Release --filter FullyQualifiedName=ct.tests.ByBitTests.Order2022IsChronological
+      - name: Order2025IsChronological
+        run: dotnet test ct/ct.tests/ct.tests.csproj --no-build --configuration Release --filter FullyQualifiedName=ct.tests.ByBitTests.Order2025IsChronological
+      - name: Volume2020Matches
+        run: dotnet test ct/ct.tests/ct.tests.csproj --no-build --configuration Release --filter FullyQualifiedName=ct.tests.ByBitTests.Volume2020Matches
+      - name: Volume2022Matches
+        run: dotnet test ct/ct.tests/ct.tests.csproj --no-build --configuration Release --filter FullyQualifiedName=ct.tests.ByBitTests.Volume2022Matches
+      - name: Volume2025Matches
+        run: dotnet test ct/ct.tests/ct.tests.csproj --no-build --configuration Release --filter FullyQualifiedName=ct.tests.ByBitTests.Volume2025Matches

--- a/ct/ct.tests/ByBitTests.cs
+++ b/ct/ct.tests/ByBitTests.cs
@@ -2,41 +2,12 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace ct.tests
 {
-    class Program
+    public class ByBitTests
     {
-        static async Task Main()
-        {
-            await RunTests();
-        }
-
-        private static async Task RunTests()
-        {
-            bool order2020 = await TestOrderAsync("BTCUSD2020-03-12.csv.gz");
-            bool order2022 = await TestOrderAsync("BTCUSD2022-06-28.csv.gz");
-            bool order2025 = await TestOrderAsync("BTCUSD2025-04-29.csv.gz");
-
-            long volume2020 = await SumVolumeAsync("BTCUSD2020-03-12.csv.gz");
-            long volume2022 = await SumVolumeAsync("BTCUSD2022-06-28.csv.gz");
-            long volume2025 = await SumVolumeAsync("BTCUSD2025-04-29.csv.gz");
-
-            if (volume2020 != 2940209655 ||
-                volume2022 != 927092462 ||
-                volume2025 != 572018150)
-            {
-                throw new Exception("Volume test failed.");
-            }
-
-            if (!order2020 || !order2022 || !order2025)
-            {
-                throw new Exception("Order test failed.");
-            }
-
-            Console.WriteLine("All tests passed.");
-        }
-
         private static async Task<bool> TestOrderAsync(string fileName)
         {
             string path = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "ct", "bybit", fileName);
@@ -66,7 +37,7 @@ namespace ct.tests
             using GZipStream zip = new GZipStream(file, CompressionMode.Decompress);
 
             DataSource source = new ByBitPublicFileDataSource(zip);
-            long volume = 0;
+            long volume = 0L;
             await foreach (Message message in source.GetMessagesAsync())
             {
                 if (message.Kind == MessageKind.Trade)
@@ -77,6 +48,48 @@ namespace ct.tests
             }
 
             return volume;
+        }
+
+        [Fact]
+        public async Task Order2020IsChronological()
+        {
+            bool order = await TestOrderAsync("BTCUSD2020-03-12.csv.gz");
+            Assert.True(order);
+        }
+
+        [Fact]
+        public async Task Order2022IsChronological()
+        {
+            bool order = await TestOrderAsync("BTCUSD2022-06-28.csv.gz");
+            Assert.True(order);
+        }
+
+        [Fact]
+        public async Task Order2025IsChronological()
+        {
+            bool order = await TestOrderAsync("BTCUSD2025-04-29.csv.gz");
+            Assert.True(order);
+        }
+
+        [Fact]
+        public async Task Volume2020Matches()
+        {
+            long volume = await SumVolumeAsync("BTCUSD2020-03-12.csv.gz");
+            Assert.Equal(2940209655L, volume);
+        }
+
+        [Fact]
+        public async Task Volume2022Matches()
+        {
+            long volume = await SumVolumeAsync("BTCUSD2022-06-28.csv.gz");
+            Assert.Equal(927092462L, volume);
+        }
+
+        [Fact]
+        public async Task Volume2025Matches()
+        {
+            long volume = await SumVolumeAsync("BTCUSD2025-04-29.csv.gz");
+            Assert.Equal(572018150L, volume);
         }
     }
 }

--- a/ct/ct.tests/ct.tests.csproj
+++ b/ct/ct.tests/ct.tests.csproj
@@ -1,13 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../ct/ct.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- switch `ct.tests` project to an xUnit test project
- rewrite the old console test runner as individual xUnit tests
- run each test separately in GitHub Actions

## Testing
- `dotnet restore ct/ct.sln` *(fails: Unable to load the service index)*