### PR TITLE
Merge identical timestamp trades

### DIFF
--- a/ct/ct/TradeMessage.cs
+++ b/ct/ct/TradeMessage.cs
@@ -14,19 +14,27 @@ namespace ct
         public readonly double Volume;
         public readonly TradeDirection Direction;
 
-        public TradeMessage(DateTime stamp, double startPrice, double endPrice, double volume, TradeDirection direction) : base(stamp)
+        private int _count;
+        public int Count => _count;
+
+        public TradeMessage(DateTime stamp, double startPrice, double endPrice, double volume, TradeDirection direction) : this(stamp, startPrice, endPrice, volume, direction, 1)
+        {
+        }
+
+        public TradeMessage(DateTime stamp, double startPrice, double endPrice, double volume, TradeDirection direction, int count) : base(stamp)
         {
             StartPrice = startPrice;
             EndPrice = endPrice;
             Direction = direction;
             Volume = volume;
+            _count = count;
         }
 
         public override MessageKind Kind => MessageKind.Trade;
 
         public override string ToString()
         {
-            return $"Trade {Stamp:O} start={StartPrice} end={EndPrice} volume={Volume} direction={Direction}";
+            return $"Trade {Stamp:O} start={StartPrice} end={EndPrice} volume={Volume} direction={Direction} count={Count}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- add count tracking to TradeMessage
- group ByBitPublicFileDataSource trades with the same timestamp and direction

## Testing
- `dotnet test ./ct/ct.tests/ct.tests.csproj --no-restore --verbosity normal` *(fails: Unable to restore packages)*