### PR TITLE
Implement candle store

### DIFF
--- a/ct/ct.tests/CandlesTests.cs
+++ b/ct/ct.tests/CandlesTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace ct.tests
+{
+    public class CandlesTests
+    {
+        [Fact]
+        public void AddCandleStoresData()
+        {
+            DateTime stamp = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            Candles candles = new Candles(TimeFrame.Minutes1);
+            Candle candle = new Candle(stamp, 1.0, 1.0, 1.0, 1.0, true, TimeFrame.Minutes1, 1.0);
+            candles.AddCandle(candle);
+
+            List<Candle> result = new List<Candle>(candles.Enumerate(TimeFrame.Minutes1, stamp, stamp.AddMinutes(1)));
+            Assert.Single(result);
+            Assert.Equal(1.0, result[0].Open);
+            Assert.Equal(1.0, result[0].Close);
+        }
+
+        [Fact]
+        public void AddTradeAggregatesCorrectly()
+        {
+            DateTime stamp = new DateTime(2024, 1, 1, 0, 5, 30, DateTimeKind.Utc);
+            Candles candles = new Candles(TimeFrame.Minutes1);
+            candles.AddTrade(stamp, 10.0, 1.0);
+            candles.AddTrade(stamp.AddSeconds(10), 12.0, 1.0);
+
+            List<Candle> result = new List<Candle>(candles.Enumerate(TimeFrame.Minutes1, new DateTime(2024, 1, 1, 0, 5, 0, DateTimeKind.Utc), new DateTime(2024, 1, 1, 0, 6, 0, DateTimeKind.Utc)));
+            Assert.Single(result);
+            Assert.Equal(10.0, result[0].Open);
+            Assert.Equal(12.0, result[0].Close);
+            Assert.Equal(12.0, result[0].High);
+            Assert.Equal(10.0, result[0].Low);
+            Assert.Equal(2.0, result[0].Volume);
+        }
+
+        [Fact]
+        public void EnumerateAggregatesLargerTimeFrame()
+        {
+            DateTime start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            Candles candles = new Candles(TimeFrame.Minutes1);
+            for (int i = 0; i < 60; i++)
+            {
+                Candle candle = new Candle(start.AddMinutes(i), i, i, i, i, true, TimeFrame.Minutes1, 1.0);
+                candles.AddCandle(candle);
+            }
+
+            List<Candle> result = new List<Candle>(candles.Enumerate(TimeFrame.Minutes15, start, start.AddHours(1)));
+            Assert.Equal(4, result.Count);
+            Assert.Equal(0.0, result[0].Open);
+            Assert.Equal(14.0, result[0].Close);
+            Assert.Equal(15.0, result[1].Open);
+            Assert.Equal(29.0, result[1].Close);
+            Assert.Equal(59.0, result[3].Close);
+            double volume = 0.0;
+            foreach (Candle c in result)
+            {
+                volume += c.Volume;
+            }
+            Assert.Equal(60.0, volume);
+        }
+
+        [Fact]
+        public void EnumerateSmallerTimeFrameThrows()
+        {
+            Candles candles = new Candles(TimeFrame.Minutes5);
+            Assert.Throws<ArgumentException>(() => new List<Candle>(candles.Enumerate(TimeFrame.Minutes1, DateTime.UnixEpoch, DateTime.UnixEpoch.AddMinutes(5))));
+        }
+    }
+}

--- a/ct/ct/Candle.cs
+++ b/ct/ct/Candle.cs
@@ -75,6 +75,9 @@ namespace ct
         private DateTime? _firstHighTime;
         private DateTime? _firstLowTime;
 
+        public DateTime? FirstHighTime => _firstHighTime;
+        public DateTime? FirstLowTime => _firstLowTime;
+
         public Candle(DateTime stamp, double open, double high, double low, double close, bool highBeforeLow, TimeFrame timeFrame, double volume)
         {
             _stamp = stamp;

--- a/ct/ct/Candles.cs
+++ b/ct/ct/Candles.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+
+namespace ct
+{
+    public class Candles
+    {
+        private readonly TimeFrame _baseTimeFrame;
+        public TimeFrame BaseTimeFrame => _baseTimeFrame;
+
+        private readonly SortedDictionary<DateTime, Candle> _candles;
+
+        public Candles(TimeFrame baseTimeFrame)
+        {
+            _baseTimeFrame = baseTimeFrame;
+            _candles = new SortedDictionary<DateTime, Candle>();
+        }
+
+        private static DateTime Align(DateTime stamp, TimeFrame timeFrame)
+        {
+            long totalSeconds = (long)(stamp - DateTime.UnixEpoch).TotalSeconds;
+            int seconds = (int)timeFrame;
+            long alignedSeconds = (totalSeconds / seconds) * seconds;
+            return DateTime.UnixEpoch.AddSeconds(alignedSeconds);
+        }
+
+        public void AddCandle(Candle candle)
+        {
+            if (candle.TimeFrame != _baseTimeFrame)
+            {
+                throw new ArgumentException("Invalid candle timeframe.");
+            }
+            _candles[candle.Stamp] = candle;
+        }
+
+        public void AddTrade(DateTime stamp, double price, double volume)
+        {
+            DateTime aligned = Align(stamp, _baseTimeFrame);
+            if (!_candles.TryGetValue(aligned, out Candle? candle))
+            {
+                candle = new Candle(aligned, price, price, price, price, true, _baseTimeFrame, 0.0);
+                _candles[aligned] = candle;
+            }
+            candle.AddTrade(stamp, price, volume);
+        }
+
+        private double GetLastClose(DateTime stamp)
+        {
+            double close = 0.0;
+            foreach (KeyValuePair<DateTime, Candle> pair in _candles)
+            {
+                if (pair.Key >= stamp)
+                {
+                    break;
+                }
+                close = pair.Value.Close;
+            }
+            return close;
+        }
+
+        private Candle CreateEmpty(DateTime stamp, double price)
+        {
+            return new Candle(stamp, price, price, price, price, true, _baseTimeFrame, 0.0);
+        }
+
+        public IEnumerable<Candle> Enumerate(TimeFrame timeFrame, DateTime from, DateTime to)
+        {
+            if ((int)timeFrame < (int)_baseTimeFrame)
+            {
+                throw new ArgumentException("Requested timeframe is smaller than base.");
+            }
+            int baseSeconds = (int)_baseTimeFrame;
+            int requestSeconds = (int)timeFrame;
+            if (requestSeconds % baseSeconds != 0)
+            {
+                throw new ArgumentException("Timeframe must be multiple of base timeframe.");
+            }
+            int ratio = requestSeconds / baseSeconds;
+            DateTime start = Align(from, _baseTimeFrame);
+            DateTime end = Align(to, _baseTimeFrame);
+            if (end < to)
+            {
+                end = end.AddSeconds(baseSeconds);
+            }
+
+            double lastClose = GetLastClose(start);
+            List<Candle> baseList = new List<Candle>();
+            for (DateTime stamp = start; stamp < end; stamp = stamp.AddSeconds(baseSeconds))
+            {
+                if (_candles.TryGetValue(stamp, out Candle? candle))
+                {
+                    baseList.Add(candle);
+                    lastClose = candle.Close;
+                }
+                else
+                {
+                    Candle empty = CreateEmpty(stamp, lastClose);
+                    baseList.Add(empty);
+                }
+            }
+
+            for (int i = 0; i < baseList.Count; i += ratio)
+            {
+                DateTime stamp = baseList[i].Stamp;
+                double open = baseList[i].Open;
+                double close = baseList[Math.Min(i + ratio - 1, baseList.Count - 1)].Close;
+                double high = open;
+                double low = open;
+                DateTime highTime = baseList[i].Stamp;
+                DateTime lowTime = baseList[i].Stamp;
+                double volume = 0.0;
+
+                for (int j = 0; j < ratio && i + j < baseList.Count; j++)
+                {
+                    Candle c = baseList[i + j];
+                    volume += c.Volume;
+                    if (c.High > high)
+                    {
+                        high = c.High;
+                        highTime = c.FirstHighTime ?? c.Stamp;
+                    }
+                    if (c.Low < low)
+                    {
+                        low = c.Low;
+                        lowTime = c.FirstLowTime ?? c.Stamp;
+                    }
+                }
+
+                bool highBeforeLow = highTime <= lowTime;
+                Candle aggregated = new Candle(stamp, open, high, low, close, highBeforeLow, timeFrame, volume);
+                yield return aggregated;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `Candles` collection for storing base timeframe candles
- expose first high/low times from `Candle`
- test candle storage, trade aggregation and enumeration

## Testing
- `dotnet test ct/ct.tests` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*