### PR TITLE
Add candle enumeration test

### DIFF
--- a/ct/ct.tests/CandlesTests.cs
+++ b/ct/ct.tests/CandlesTests.cs
@@ -69,5 +69,31 @@ namespace ct.tests
             Candles candles = new Candles(TimeFrame.Minutes5);
             Assert.Throws<ArgumentException>(() => new List<Candle>(candles.Enumerate(TimeFrame.Minutes1, DateTime.UnixEpoch, DateTime.UnixEpoch.AddMinutes(5))));
         }
+
+        [Fact]
+        public void ForeachAggregatesToFiveMinutes()
+        {
+            DateTime start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            Candles candles = new Candles(TimeFrame.Minutes1);
+            for (int i = 0; i < 10; i++)
+            {
+                DateTime stamp = start.AddMinutes(i).AddSeconds(10);
+                candles.AddTrade(stamp, i + 1.0, 1.0);
+            }
+
+            List<Candle> result = new List<Candle>();
+            foreach (Candle candle in candles.Enumerate(TimeFrame.Minutes5, start, start.AddMinutes(10)))
+            {
+                result.Add(candle);
+            }
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(1.0, result[0].Open);
+            Assert.Equal(5.0, result[0].Close);
+            Assert.Equal(6.0, result[1].Open);
+            Assert.Equal(10.0, result[1].Close);
+            Assert.Equal(5.0, result[0].Volume);
+            Assert.Equal(5.0, result[1].Volume);
+        }
     }
 }

--- a/ct/ct/Program.cs
+++ b/ct/ct/Program.cs
@@ -9,6 +9,8 @@ namespace ct
     {
         static async Task Main(string[] args)
         {
+            DemoCandles();
+
             string path = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "bybit", "BTCUSD2020-03-12.csv.gz");
             using FileStream file = File.OpenRead(path);
             using GZipStream zip = new GZipStream(file, CompressionMode.Decompress);
@@ -21,6 +23,22 @@ namespace ct
                 {
                     break;
                 }
+            }
+        }
+
+        private static void DemoCandles()
+        {
+            DateTime start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            Candles candles = new Candles(TimeFrame.Minutes1);
+            for (int i = 0; i < 10; i++)
+            {
+                DateTime stamp = start.AddMinutes(i).AddSeconds(10);
+                candles.AddTrade(stamp, i + 1.0, 1.0);
+            }
+
+            foreach (Candle candle in candles.Enumerate(TimeFrame.Minutes5, start, start.AddMinutes(10)))
+            {
+                Console.WriteLine($"{candle.Stamp:O} O:{candle.Open} H:{candle.High} L:{candle.Low} C:{candle.Close} V:{candle.Volume}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a test that builds 1 minute candles from trades
- iterate over aggregated 5 minute candles and verify content
- demonstrate the same behavior in Program.cs for quick debugging

## Testing
- `dotnet test` *(fails: unable to restore nuget packages)*